### PR TITLE
Remove hardcoded I2C bus

### DIFF
--- a/lib/nerves_key_pkcs11.ex
+++ b/lib/nerves_key_pkcs11.ex
@@ -5,6 +5,13 @@ defmodule NervesKey.PKCS11 do
   use the shared library.
   """
 
+  @typedoc """
+  The location of the NervesKey
+
+  Currently only I2C bus locations are supported.
+  """
+  @type location :: {:i2c, 0..15}
+
   @doc """
   Load the OpenSSL engine
   """
@@ -33,9 +40,17 @@ defmodule NervesKey.PKCS11 do
   use to properly route private key operations to the PKCS #11
   shared library.
   """
-  def private_key(engine) do
-    %{algorithm: :ecdsa, engine: engine, key_id: "pkcs11:id=0;type=private"}
+  @spec private_key(:crypto.engine_ref(), location()) :: map()
+  def private_key(engine, location) do
+    %{
+      algorithm: :ecdsa,
+      engine: engine,
+      key_id: "pkcs11:id=#{location_to_slot_id(location)}"
+    }
   end
+
+  defp location_to_slot_id({:i2c, bus_number}) when bus_number >= 0 and bus_number <= 16,
+    do: bus_number
 
   defp pkcs11_path() do
     [

--- a/src/atecc508a.c
+++ b/src/atecc508a.c
@@ -353,7 +353,7 @@ int atecc508a_derive_public_key(int fd, uint8_t slot, uint8_t *key)
 {
     // Send a GenKey command to derive the public key from a previously stored private key
     uint8_t msg[11];
-INFO("PUBLIC_KEY!!!!!");
+
     if (atecc508a_wakeup(fd) < 0)
         return -1;
 

--- a/src/log.h
+++ b/src/log.h
@@ -35,7 +35,7 @@
 
 #define PROGNAME "nerves_key_pkcs11"
 
-#define DEBUG
+//#define DEBUG
 #ifdef DEBUG
 #define ENTER() do { fprintf(stderr, "%s: Entered %s().\r\n", PROGNAME, __func__); } while (0)
 

--- a/test/nerves_key_pkcs11_test.exs
+++ b/test/nerves_key_pkcs11_test.exs
@@ -9,11 +9,20 @@ defmodule NervesKey.PKCS11Test do
 
   test "creates a key map" do
     engine = make_ref()
-    key = NervesKey.PKCS11.private_key(engine)
+    key = NervesKey.PKCS11.private_key(engine, {:i2c, 0})
 
     assert is_map(key)
     assert Map.get(key, :algorithm) == :ecdsa
     assert Map.get(key, :engine) == engine
-    assert Map.get(key, :key_id) == "pkcs11:id=0;type=private"
+    assert Map.get(key, :key_id) == "pkcs11:id=0"
+  end
+
+  test "maps I2C locations" do
+    engine = make_ref()
+    key = NervesKey.PKCS11.private_key(engine, {:i2c, 1})
+    assert Map.get(key, :key_id) == "pkcs11:id=1"
+
+    key = NervesKey.PKCS11.private_key(engine, {:i2c, 3})
+    assert Map.get(key, :key_id) == "pkcs11:id=3"
   end
 end


### PR DESCRIPTION
The slot-id is now the I2C bus. This isn't great, but it's simple.