### PR TITLE
Add docs for auxiliary keys even though not needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,23 @@ crosscompiling.
 
 ## Slot definition
 
-PKCS #11 uses the term slot to refer to cryptographic devices. This library
-can use either slot ID (if called directly) or the slot's token ID (if called
-via libp11) to find the NervesKey. The following table shows the mapping
-from slot to device.
+PKCS #11 uses the term slot to refer to cryptographic devices. This library can
+use either slot ID (if called directly) or the slot's token ID (if called via
+libp11) to find the NervesKey. Various parameters are mapped into the slot ID
+according to the table below:
 
-Slot range  | Description
-------------|------------
-0-15        | I2C bus 0-15 (i.e. /dev/i2c-0, etc.), ATECC508A at address 0x60 (the default)
+Slot range  | I2C bus   | Bus address | Certificate
+------------|-----------|-------------|------------
+0-15        | slot      | 0x60        | Primary or auxiliary
+
+On Linux, the I2C bus number in the table above determines the device file. For
+example, a bus number of "1" maps to `/dev/i2c-1`. NervesKey devices support a
+primary and auxiliary set of certificates. Normally only the primary device
+certificate is used. Under some conditions, it's useful to write a second set of
+certificates to the device and those can be referenced by using the "Auxiliary"
+rows in the table.  This library currently need to differentiate between primary
+and auxiliary certificates so that's not represented in the slot ID. It may be
+in the future.
 
 The [PKCS #11 URI](https://tools.ietf.org/html/rfc7512) for addressing the
 desired NervesKey has the form:
@@ -93,7 +102,7 @@ options, you'll have something like this:
 
 ```elixir
 [
-  key: NervesKey.PKCS11.private_key(engine, {:i2c, 1}),
+  key: NervesKey.PKCS11.private_key(engine, i2c: 1),
   certfile: "device-cert.pem",
 ]
 ```

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,10 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.4", "71b42f5ee1b7628f3e3a6565f4617dfb02d127a0499ab3e72750455e986df001", [:mix], [{:erlex, "~> 0.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.3.0", "17f0c38eaafb4800f746b457313af4b2442a8c2405b49c645768680f900be603", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
   "erlex": {:hex, :erlex, "0.1.6", "c01c889363168d3fdd23f4211647d8a34c0f9a21ec726762312e08e083f3d47e", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.5.6", "da47b331b1fe0a5f0380cc3a6967200eac5e1daaa9c6bff4b0310b3fcc12b98f", [:mix], [{:nimble_parsec, "~> 0.4.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
 }

--- a/test/nerves_key_pkcs11_test.exs
+++ b/test/nerves_key_pkcs11_test.exs
@@ -9,7 +9,7 @@ defmodule NervesKey.PKCS11Test do
 
   test "creates a key map" do
     engine = make_ref()
-    key = NervesKey.PKCS11.private_key(engine, {:i2c, 0})
+    key = NervesKey.PKCS11.private_key(engine, i2c: 0)
 
     assert is_map(key)
     assert Map.get(key, :algorithm) == :ecdsa
@@ -19,10 +19,26 @@ defmodule NervesKey.PKCS11Test do
 
   test "maps I2C locations" do
     engine = make_ref()
-    key = NervesKey.PKCS11.private_key(engine, {:i2c, 1})
+    key = NervesKey.PKCS11.private_key(engine, i2c: 1)
     assert Map.get(key, :key_id) == "pkcs11:id=1"
 
-    key = NervesKey.PKCS11.private_key(engine, {:i2c, 3})
+    key = NervesKey.PKCS11.private_key(engine, i2c: 3)
     assert Map.get(key, :key_id) == "pkcs11:id=3"
+  end
+
+  test "accepts aux and primary" do
+    # These don't do anything now, but we may need them in the future.
+    engine = make_ref()
+    key = NervesKey.PKCS11.private_key(engine, i2c: 1, certificate: :aux)
+    assert Map.get(key, :key_id) == "pkcs11:id=1"
+
+    key = NervesKey.PKCS11.private_key(engine, i2c: 1, certificate: :primary)
+    assert Map.get(key, :key_id) == "pkcs11:id=1"
+  end
+
+  test "supports old option format for the time being" do
+    engine = make_ref()
+    key = NervesKey.PKCS11.private_key(engine, {:i2c, 0})
+    assert Map.get(key, :key_id) == "pkcs11:id=0"
   end
 end


### PR DESCRIPTION
It felt really wrong to not address the difference between the auxiliary and primary certs when using this library. Since they share the same private key, it's unnecessary. This led me to refactor how options were passed to the `private_key` helper method. The old way is still supported so no code is broken.