### PR TITLE
Use token in pkcs11 URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The [PKCS #11 URI](https://tools.ietf.org/html/rfc7512) for addressing the
 desired NervesKey has the form:
 
 ```text
-pkcs11:id=1
+pkcs11:token=1
 ```
 
 ## OpenSSL integration

--- a/lib/nerves_key_pkcs11.ex
+++ b/lib/nerves_key_pkcs11.ex
@@ -65,7 +65,7 @@ defmodule NervesKey.PKCS11 do
     %{
       algorithm: :ecdsa,
       engine: engine,
-      key_id: "pkcs11:id=#{slot_id}"
+      key_id: "pkcs11:token=#{slot_id}"
     }
   end
 

--- a/test/nerves_key_pkcs11_test.exs
+++ b/test/nerves_key_pkcs11_test.exs
@@ -14,31 +14,31 @@ defmodule NervesKey.PKCS11Test do
     assert is_map(key)
     assert Map.get(key, :algorithm) == :ecdsa
     assert Map.get(key, :engine) == engine
-    assert Map.get(key, :key_id) == "pkcs11:id=0"
+    assert Map.get(key, :key_id) == "pkcs11:token=0"
   end
 
   test "maps I2C locations" do
     engine = make_ref()
     key = NervesKey.PKCS11.private_key(engine, i2c: 1)
-    assert Map.get(key, :key_id) == "pkcs11:id=1"
+    assert Map.get(key, :key_id) == "pkcs11:token=1"
 
     key = NervesKey.PKCS11.private_key(engine, i2c: 3)
-    assert Map.get(key, :key_id) == "pkcs11:id=3"
+    assert Map.get(key, :key_id) == "pkcs11:token=3"
   end
 
   test "accepts aux and primary" do
     # These don't do anything now, but we may need them in the future.
     engine = make_ref()
     key = NervesKey.PKCS11.private_key(engine, i2c: 1, certificate: :aux)
-    assert Map.get(key, :key_id) == "pkcs11:id=1"
+    assert Map.get(key, :key_id) == "pkcs11:token=1"
 
     key = NervesKey.PKCS11.private_key(engine, i2c: 1, certificate: :primary)
-    assert Map.get(key, :key_id) == "pkcs11:id=1"
+    assert Map.get(key, :key_id) == "pkcs11:token=1"
   end
 
   test "supports old option format for the time being" do
     engine = make_ref()
     key = NervesKey.PKCS11.private_key(engine, {:i2c, 0})
-    assert Map.get(key, :key_id) == "pkcs11:id=0"
+    assert Map.get(key, :key_id) == "pkcs11:token=0"
   end
 end


### PR DESCRIPTION
It turns out that `pkcs11:id=x` wasn't being matched and libp11 would
select the last valid ID. This would be the highest numbered I2C bus
(i.e., the last one checked). Out of an amazing amount of luck,
NervesKeys were being put on the highest numbered I2C bus apparently.

The fix is to specify `pkcs11:token=x`.

See the code snippet here for the match logic:

https://github.com/OpenSC/libp11/blob/6064a0a8fef06d96f3e6e13f02b2f0513aa93214/src/eng_back.c#L473-L483

The word `token` maps to `match_tok->label`. The ID isn't checked in
the loop so all slots match. This library makes a slot per I2C bus and
they're made in order. The last match wins in that code. Therefore, if
you have `i2c-0` and `i2c-1`, the ATECC608A has to be on `i2c-1` to
work.