### PR TITLE
Fix segfault with libp11 v0.4.11

### DIFF
--- a/src/nerves_key_pkcs11.c
+++ b/src/nerves_key_pkcs11.c
@@ -966,7 +966,7 @@ CK_DEFINE_FUNCTION(CK_RV, C_Sign)(
 
     if (pSignature == NULL_PTR) {
         *pulSignatureLen = 64;
-        return CKR_OK;
+        return CKR_BUFFER_TOO_SMALL;
     } else if (*pulSignatureLen < 64) {
         *pulSignatureLen = 64;
         return CKR_BUFFER_TOO_SMALL;


### PR DESCRIPTION
For reasons that aren't clear to me libp11 v0.4.11 has started probing
the ECC signature length. libp11 v0.4.10 does not do this. A probe
consists of passing a NULL signature into C_Sign(). Previously this code
returned success - most likely it was copy-paste and it seemed
reasonable. However, now that libp11 probes the length with a NULL
signature, the success response caused a code path in libp11 to be
followed that deferenced the NULL pointer. Returning a signature too
short error causes the right code path to be followed.
