### PR TITLE
Switch to :crypto.ensure_engine_loaded to avoid multiple loads

### DIFF
--- a/lib/nerves_key_pkcs11.ex
+++ b/lib/nerves_key_pkcs11.ex
@@ -32,12 +32,13 @@ defmodule NervesKey.PKCS11 do
       """
     end
 
-    # Load libpkcs11.so using OpenSSL's dynamic engine and then configure it
-    :crypto.engine_load(
-      "dynamic",
-      [{"SO_PATH", libpkcs}, {"ID", "pkcs11"}, {"LOAD", ""}],
-      [{"MODULE_PATH", Application.app_dir(:nerves_key_pkcs11, ["priv", "nerves_key_pkcs11.so"])}]
-    )
+    nk = Application.app_dir(:nerves_key_pkcs11, ["priv", "nerves_key_pkcs11.so"])
+
+    # Load the p11 adapter and configure it with the nerves_key_pkcs11.so implementation
+    with {:ok, engine} <- :crypto.ensure_engine_loaded("pkcs11", libpkcs),
+         :ok <- :crypto.engine_ctrl_cmd_string(engine, "MODULE_PATH", nk) do
+      {:ok, engine}
+    end
   end
 
   @doc """

--- a/test/nerves_key_pkcs11_test.exs
+++ b/test/nerves_key_pkcs11_test.exs
@@ -7,6 +7,17 @@ defmodule NervesKey.PKCS11Test do
     assert is_reference(engine)
   end
 
+  test "can load an engine twice" do
+    # This tests the logic that prevents multiple loads if using libopenssl
+    # 1.1.1m or later.  Those versions of libopenssl will fail the second
+    # engine load if attempted.
+    {:ok, engine} = NervesKey.PKCS11.load_engine()
+    assert is_reference(engine)
+
+    {:ok, engine2} = NervesKey.PKCS11.load_engine()
+    assert is_reference(engine2)
+  end
+
   test "creates a key map" do
     engine = make_ref()
     key = NervesKey.PKCS11.private_key(engine, i2c: 0)


### PR DESCRIPTION
OpenSSL 1.1.1m detects multiple attempts to load a shared library and
returns errors. This switches how the engine is loaded to prevent
multiple loads.

nerves_key_pkcs11's minimum supported OTP version is now OTP 21.0.6.
Note that we haven't been testing on OTP 20 so this doesn't have an
impact to CI.
