### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NervesKey.PKCS11
 
 [![Hex version](https://img.shields.io/hexpm/v/nerves_key_pkcs11.svg "Hex version")](https://hex.pm/packages/nerves_key_pkcs11)
-[![API docs](https://img.shields.io/hexpm/v/nerves_key_pkcs11.svg?label=hexdocs "API docs")](https://hexdocs.pm/nerves_key_pkcs11/NervesKey.PKCS11.html)
+[![API docs](https://img.shields.io/hexpm/v/nerves_key_pkcs11.svg?label=hexdocs "API docs")](https://nerves-key-pkcs11.hexdocs.pm/NervesKey.PKCS11.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-hub/nerves_key_pkcs11/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-hub/nerves_key_pkcs11/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-hub/nerves_key_pkcs11)](https://api.reuse.software/info/github.com/nerves-hub/nerves_key_pkcs11)
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://nerves-key-pkcs11.hexdocs.pm/NervesKey.PKCS11.html): Status 404
⚠️ Verification finished: 0 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>